### PR TITLE
(QA-1928) Fix Bug

### DIFF
--- a/lib/master_manipulator/site.rb
+++ b/lib/master_manipulator/site.rb
@@ -71,16 +71,11 @@ MANIFEST
     #
     # set_perms_on_remote(master, "/tmp/test/site.pp", "777")
     def set_perms_on_remote(host, path, mode, opts = {})
-      if (opts[:owner].nil?)
-        owner = on(host, puppet('config print user')).stdout.rstrip
-      end
-
-      if (opts[:group].nil?)
-        group = on(host, puppet('config print group')).stdout.rstrip
-      end
+      opts[:owner] ||= on(host, puppet('config print user')).stdout.rstrip
+      opts[:group] ||= on(host, puppet('config print group')).stdout.rstrip
 
       on(host, "chmod -R #{mode} #{path}")
-      on(host, "chown -R #{owner}:#{group} #{path}")
+      on(host, "chown -R #{opts[:owner]}:#{opts[:group]} #{path}")
     end
 
     # Inject temporary "site.pp" onto target host. This will also create


### PR DESCRIPTION
The "set_perms_on_remote" method fails to set ownership on a file and is
now fixed!
