### PR TITLE
(MAINT) Prepare Gemspec for initial public release

### DIFF
--- a/master_manipulator.gemspec
+++ b/master_manipulator.gemspec
@@ -4,31 +4,28 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'master_manipulator/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "master_manipulator"
+  spec.name          = 'master_manipulator'
   spec.version       = MasterManipulator::Version::STRING
-  spec.authors       = ["Puppetlabs"]
-  spec.email         = ["qa@puppetlabs.com"]
-  spec.summary       = %q{Puppetlabs testing library for Beaker}
-  spec.description   = %q{Puppetlabs testing library for controlling a Puppet Master}
-  spec.homepage      = "https://github.com/puppetlabs/master_manipulator"
-  spec.license       = "Apache2"
+  spec.authors       = ['Puppet Labs']
+  spec.email         = ['qa@puppetlabs.com']
+  spec.summary       = 'Puppet Labs testing library for controlling a Puppet Master'
+  spec.description   = 'This Gem extends the Beaker DSL for the purpose of changing things on a Puppet Master.'
+  spec.homepage      = 'https://github.com/puppetlabs/master_manipulator'
+  spec.license       = 'Apache-2.0'
+  spec.files         = Dir['[A-Z]*[^~]'] + Dir['lib/**/*.rb'] + Dir['spec/*']
+  spec.test_files    = Dir['spec/*']
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
-
-  #Development dependencies
+  # Development dependencies
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'pry', '~> 0.9.12'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.0.0'
   spec.add_development_dependency 'simplecov'
 
-  #Documentation dependencies
+  # Documentation dependencies
   spec.add_development_dependency 'yard', '~> 0'
   spec.add_development_dependency 'markdown', '~> 0'
 
-  #Run time dependencies
+  # Run time dependencies
   spec.add_runtime_dependency 'beaker', '~> 2.7', '>= 2.7.0'
 end


### PR DESCRIPTION
Updated Gemspec to newer general Ruby and Rubygem standards
(http://guides.rubygems.org/specification-reference/), which includes:

Use single-quoted strings instead of double-string when interpolation
isn't needed.

Provide a slightly better description.

Update the Gem author with the same 'author' as our other public gems.

Correct OSI license name
  (http://opensource.org/licenses/alphabetical).

Use Ruby to generate the files to package, instead of shelling out to
git on the command line.

Removing attributes that are unused, like spec.executables and
spec.require_paths (since it defaults to 'lib/').
