### PR TITLE
[REVIEW ONLY - DO NOT MERGE] (QA-2605) Import QA test libs from FOSS puppetserver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,4 @@
 source 'https://rubygems.org'
-#this will probably not be available on rubygems, at least initially
-#will probably be only available at https://rubygems.delivery.puppetlabs.net
-#TODO: Change this line when it is actually available internally
 
 # Specify your gem's dependencies in master_manipulator.gemspec
 gemspec

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 # default - History
 ## Tags
-* [LATEST - 20 Nov, 2015 (b37806b8)](#LATEST)
+* [1.9.99 - 23 Aug, 2016 (c28a7eee)](#LATEST)
+* [1.2.3 - 20 Nov, 2015 (b37806b8)](#1.2.3)
 * [1.2.2 - 30 Oct, 2015 (31450d3c)](#1.2.2)
 * [1.2.1 - 30 Oct, 2015 (b59fd2cf)](#1.2.1)
 * [1.2.0 - 29 Oct, 2015 (6d0873f7)](#1.2.0)
@@ -11,8 +12,21 @@
 * [1.0.0 - 6 May, 2015 (8ae50d90)](#1.0.0)
 
 ## Details
-### <a name = "LATEST">LATEST - 20 Nov, 2015 (b37806b8)
 
+### <a name = "LATEST">LATEST - 23 Aug, 2016 (b37806b8)
+
+(QA-2605) Extract FOSS puppetserver test libraries to master_manipulator 
+* Update Gemfile per TODO 
+* No, not that file 
+* Use the internal rubygems mirror 
+* Bump version number for new release 
+* Silence some warnings from gem build 
+* Additional methods and cleanup 
+* Add comments and documentation 
+* Fix calling conventions
+* Update HISTORY file
+
+### <a name="1.2.3">1.2.3 20 Nov, 2015 (b37806b8)
 * (GEM) update master_manipulator version to 1.2.3 (b37806b8)
 
 * Merge pull request #16 from zreichert/make_master_manipulator_3.8_compatible (9d2073ff)

--- a/lib/master_manipulator/service.rb
+++ b/lib/master_manipulator/service.rb
@@ -1,72 +1,227 @@
 require 'json'
+require 'net/http'
+require 'uri'
 
 module MasterManipulator
   module Service
-
     # Restart the puppet server and wait for it to come back up
     # ==== Attributes
     # *+host+ - the host that this should operate on
     # *+opts+ - an options hash - not required
     #   *+:wait_cycle+ - the number of cycles to attempt retry
     #   *+:is_pe?+ - Boolean : if the SUT is PE, defaults to true
+    #   *+:hup?+ - Boolean : if true, reload server; if false, restart server; defaults to false
     #
     # Raises a standard error if the wait is unsuccessful
     #
     # ==== Example
     # restart_puppet_server(master)
     # restart_puppet_server(master, {:wait_cycles => 20})
-    def restart_puppet_server(host, opts = {})
-
+    # restart_puppet_server(master, {:is_pe? => false, :hup? => true})
+    def restart_puppet_server(host, opts = {:is_pe? => true, :hup? => false})
       start_time = Time.now
 
-      opts[:is_pe?] ||= true
       opts[:is_pe?] ? service_name = 'pe-puppetserver' : service_name = 'puppetserver'
-
-      on(host, puppet("resource service #{service_name} ensure=stopped"))
-      on(host, puppet("resource service #{service_name} ensure=running"))
-      hostname = on(host, 'hostname').stdout.chomp
-      opts[:wait_cycles] ||= 10
-
-      pe_ver = pe_version(host)
-      three_eight_regex = /^3\.8/
-
-      # This logic is not ideal refactor in the future
-      # if its PE and not 3.8 use the status endpoint
-      # it its not PE or it is 3.8 use the simple curl call
-      if pe_ver && !pe_ver.match(three_eight_regex)
-        curl_call = "-k -X GET -H 'Content-Type: application/json' https://#{hostname}:8140/status/v1/services?level=debug"
+    
+      if opts[:hup?]
+        hup_service(host, service_name)
+        return
       else
-        curl_call = "-I -k https://#{hostname}:8140"
+        on(host, puppet("resource service #{service_name} ensure=stopped"))
+        on(host, puppet("resource service #{service_name} ensure=running"))
       end
 
-      (1..opts[:wait_cycles]).each do |i|
+      if opts[:is_pe?]
+        opts[:wait_cycles] ||= 10
+        pe_ver = pe_version(host)
+        three_eight_regex = /^3\.8/
+        
+        # FIXME: This logic is not ideal refactor in the future
+        # if its PE and not 3.8 use the status endpoint
+        # it its not PE or it is 3.8 use the simple curl call
+        # FIXME: Replace curl calls with http_request calls
+        hostname = host.hostname
+        if !pe_ver.match(three_eight_regex)
+          curl_call = "--head --insecure https://#{hostname}:8140"
+        else
+          curl_call = "--insecure --request GET --header 'Content-Type: application/json' https://#{hostname}:8140/status/v1/services?level=debug"
+        end
 
-        @result = curl_on(host, curl_call, :acceptable_exit_codes => [0,1,7])
-        # parse body if we are using PE and we are not in PE 3.8
-        (pe_ver && !pe_ver.match(three_eight_regex)) ? @body = JSON.parse(@result.stdout) : @body = []
-
-        case @result.exit_code.to_s
+        (1..opts[:wait_cycles]).each do |i|
+          @result = curl_on(host, curl_call, :acceptable_exit_codes => [0,1,7])
+          # parse body if we are using PE and we are not in PE 3.8
+          @body = (pe_ver && !pe_ver.match(three_eight_regex)) ? JSON.parse(@result.stdout) : []
+          
+          case @result.exit_code.to_s
           when '0'
             sleep 20
             pe_ver.match(/three_eight_regex/) ? return : (return if @body.all? { |k, v| v['state'] == 'running' })
           when '1', '7'
             # Exit code 7 is "connection refused"
             sleep (i**(1.2))
+          end
         end
+
+        total_time = Time.now - start_time
+        
+        message = "Attempted to restart #{opts[:wait_cycles]} times, " +
+          "waited #{total_time} seconds total. \nHere is the status " +
+          "reported by the puppetserver:\n"
+        @body.each do |k,v|
+          message << "\n'#{k}' state: #{v['state']} "
+        end
+        raise message
+      end
+    end
+
+    # Send SIGHUP to service_name on host and wait for reload to complete
+    # ==== Attributes
+    # *+host+ - the host that this should operate on
+    # *+service_name+ - the service to restart
+    #
+    # ==== Example
+    # hup_service(master, 'puppetserver')
+    # hup_service(host, 'pe-puppetserver')
+    def hup_service(host, service_name)
+      timeout = 30
+
+      # FIXME: This should be replaced either by invoking "puppetserver reload"
+      # after EZ-68 gets merged
+      pid = on(host, "pgrep -fo #{service_name}").stdout.strip
+      on(host, "kill -HUP #{pid}")
+      sleep timeout
+
+      # FIXME This should use the new status endpoint /status/v1/services?level=debug"
+      url = "https://#{host}:8140/puppet/v3/status"
+      cert = get_cert(host)
+      key = get_key(host)
+      response_code = "0"
+      sleeptime = 1
+      while response_code != "200" && timeout > 0
+        sleep sleeptime
+        begin
+          response = https_request(url, 'GET', cert, key)
+        rescue StandardError => e
+          expected_errors = [ EOFError, Errno::ECONNREFUSED, Errno::ECONNRESET,
+                              OpenSSL::SSL::SSLError ]
+          if !expected_errors.include?e.class
+            raise e
+          else
+            puts "Ignoring expected exception #{e}; server is restarting"
+          end
+        end
+        response_code = response.code unless response == nil
+        timeout = timeout - sleeptime
+      end      
+    end
+    
+    # Fetch the host cert from the specified host and return it as an
+    # OpenSSL::X509::Certificate object
+    # ==== Attributes
+    # *+host+ - the host from which to fetch the cert
+    #
+    # ==== Example
+    # get_cert(master)
+    def get_cert(host)
+      if host.host_hash[:cert].class == OpenSSL::X509::Certificate
+	return host.host_hash[:cert]
+      else
+        cert = encode_cert(host, host.puppet['hostcert'])
+	host.host_hash[:cert] = cert
+	return cert
+      end
+    end
+
+    # Fetch the host's private key from the specified host and return it
+    # as an OpenSSL::PKey::RSA object
+    # ==== Attributes
+    # *+host+ - the host from which to fetch the key
+    #
+    # ==== Example
+    # get_key(master)
+    def get_key(host)
+      if host.host_hash[:key].class == OpenSSL::PKey::RSA
+	return host.host_hash[:key]
+      else
+        key = encode_key(host, host.puppet['hostprivkey'])
+        host.host_hash[:key] = key
+	return key
+      end
+    end
+
+    # Convert the contents of the certificate file in cert_file on the host
+    # specified by cert_host into an X.509 certificate and return it
+    # ==== Attributes
+    # *+cert_host+ - The host whose cert you want
+    # *+cert_file+ - The specific cert file you want
+    # *+silent+ - Suppress beaker's output; set to false to see it
+    #
+    # ==== Examples
+    # encode_cert(master, '/etc/ssl/private/host.cert')
+    # encode_cert(master, '/etc/ssl/private/host.cert', false)
+    def encode_cert(cert_host, cert_file, silent = true)
+      rawcert = on(cert_host, "cat #{cert_file}", {:silent => silent}).stdout.strip
+      OpenSSL::X509::Certificate.new(rawcert)
+    end
+
+    # Convert the contents of the private key file in key_file on the host
+    # specified by key_host into an RSA private key and return it
+    # ==== Attributes
+    # *+key_host+ - The host whose key you want
+    # *+key_file+ - The specific key file you want
+    # *+silent+ - Suppress beaker's output; set to false to see it
+    #
+    # ==== Examples
+    # encode_key(master, '/etc/ssl/private/host.key')
+    # encode_key(agent, '/etc/ssl/private/host.key', :silent => false)
+    def encode_key(key_host, key_file, silent = true)
+      rawkey = on(key_host, "cat #{key_file}", {:silent => silent}).stdout.strip
+      OpenSSL::PKey::RSA.new(rawkey)
+    end
+
+    # Issue an HTTP request and return the Net::HTTPResponse object. Lifted from
+    # pe_acceptance_tests/2015.3.x/lib/http_calls.rb and slightly modified.
+    # ==== Attributes
+    # **url+ - (String) URL to poke
+    # **method+ - (Symbol) :post, :get
+    # **cert+ - (OpenSSL::X509::Certificate, String) The certificate to
+    #       use for authentication.
+    # **key+ - (OpenSSL::PKey::RSA, String) The private key to use for
+    #      authentication
+    # **body+ - (String) Request body (default empty)
+    #
+    # ==== Examples
+    def https_request(url, request_method, cert, key, body = nil)
+      # Make insecure https request
+      uri = URI.parse(url)
+      http = Net::HTTP.new(uri.host, uri.port)
+
+      if cert.is_a?(OpenSSL::X509::Certificate)
+        http.cert = cert
+      else
+        raise TypeError, 
+          "cert must be an OpenSSL::X509::Certificate object, not #{cert.class}"
       end
 
-      total_time = Time.now - start_time
-
-      message = "Attempted to restart #{opts[:wait_cycles]} times, waited #{total_time} seconds total."
-
-      message << "\nHere is the status reported by the puppetserver'"
-
-      @body.each do |k,v|
-        message << "\n'#{k}' state: #{v['state']} "
+      if key.is_a?(OpenSSL::PKey::RSA)
+        http.key = key
+      else
+        raise TypeError,
+        "key must be an OpenSSL::PKey:RSA object, not #{key.class}"
       end
 
-      raise message
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
+      if request_method == :post
+        request = Net::HTTP::Post.new(uri.request_uri)
+        # Needs the content type even though no data is being sent
+        request.content_type = 'application/json'
+        request.body = body
+      else
+        request = Net::HTTP::Get.new(uri.request_uri)
+      end
+      response = http.request(request)
     end
 
     # Determine the version of PE installed on the master

--- a/lib/master_manipulator/service.rb
+++ b/lib/master_manipulator/service.rb
@@ -21,6 +21,10 @@ module MasterManipulator
     def restart_puppet_server(host, opts = {:is_pe? => true, :hup? => false})
       start_time = Time.now
 
+      if :hup?.class != TrueClass && :hup?.class != FalseClass
+        raise TypeError, ':hup? must be boolean (true/false)'
+      end
+
       opts[:is_pe?] ? service_name = 'pe-puppetserver' : service_name = 'puppetserver'
     
       if opts[:hup?]

--- a/lib/master_manipulator/version.rb
+++ b/lib/master_manipulator/version.rb
@@ -1,5 +1,5 @@
 module MasterManipulator
   module Version
-    STRING = '1.2.3'
+    STRING = '2.0.00'
   end
 end

--- a/master_manipulator.gemspec
+++ b/master_manipulator.gemspec
@@ -4,16 +4,16 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'master_manipulator/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'master_manipulator'
-  spec.version       = MasterManipulator::Version::STRING
-  spec.authors       = ['Puppet Labs']
-  spec.email         = ['qa@puppetlabs.com']
-  spec.summary       = 'Puppet Labs testing library for controlling a Puppet Master'
-  spec.description   = 'This Gem extends the Beaker DSL for the purpose of changing things on a Puppet Master.'
-  spec.homepage      = 'https://github.com/puppetlabs/master_manipulator'
-  spec.license       = 'Apache-2.0'
-  spec.files         = Dir['[A-Z]*[^~]'] + Dir['lib/**/*.rb'] + Dir['spec/*']
-  spec.test_files    = Dir['spec/*']
+  spec.name        = 'master_manipulator'
+  spec.version     = MasterManipulator::Version::STRING
+  spec.authors     = ['Puppet']
+  spec.email       = ['qa@puppet.com']
+  spec.summary     = 'Puppet testing library for controlling a Puppet Master'
+  spec.description = 'This Gem extends the Beaker DSL for the purpose of changing things on a Puppet Master.'
+  spec.homepage    = 'https://github.com/puppetlabs/master_manipulator'
+  spec.license     = 'Apache-2.0'
+  spec.files       = Dir['[A-Z]*[^~]'] + Dir['lib/**/*.rb'] + Dir['spec/*']
+  spec.test_files  = Dir['spec/*']
 
   # Development dependencies
   spec.add_development_dependency 'bundler', '~> 1.6'

--- a/spec/master_manipulator/service_spec.rb
+++ b/spec/master_manipulator/service_spec.rb
@@ -15,7 +15,7 @@ describe MasterManipulator::Service do
     expect(dummy_class).to receive(:on).with(beaker_host, beaker_command).twice
     expect(dummy_class).to receive(:puppet).with(cmd_1).and_return(beaker_command)
     expect(dummy_class).to receive(:puppet).with(cmd_2).and_return(beaker_command)
-    expect(dummy_class).to receive(:on).with(beaker_host, cmd_3).and_return(beaker_result)
+    expect(beaker_host).to receive(:hostname).and_return('foobar.puppetlabs.net')
   end
 
   context 'compatibility with 3.8' do


### PR DESCRIPTION
This commit adds QA test helpers to master_manipulator that will be removed from FOSS puppetserver in [PR #1179](https://github.com/puppetlabs/puppetserver/pull/1179). It needs more work and there are potentially two more methods to move. In particular, I'll need to pair with someone to write spec tests or at least get some reliable pointers on how to get started.