### PR TITLE
(QA-2789) Revise Master Manipulator docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ build/
 ## Documentation cache and generated files:
 /.yardoc/
 /_yardoc/
-/doc/
 /rdoc/
 
 ## Environment normalisation:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Master Manipulator
 
 This gem extends the Beaker DSL for the purpose of changing things on a
-Pupppet master.
+Puppet master.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,127 +1,34 @@
+
 # Master Manipulator
 
-This Gem extends the Beaker DSL for the purpose of changing things on a
-Puppet Master.
+This gem extends the Beaker DSL for the purpose of changing things on a
+Pupppet master.
 
 ## Installation
 
+### Using a Gemfile
+
 Add this line to your application's Gemfile:
 
+```
     gem 'master_manipulator'
+```
 
 And then execute:
 
-    $ bundle
+```
+    bundle install
+```
 
-Or install it yourself as:
+or your preferred invocation for installing gems.
 
-    $ gem install master_manipulator
+### Using Rubygems
 
-## Methods
+To install the gem yourself:
 
-### disable_node_classifier
 
-Disable the node classifier on a Puppet Enterprise master and use the "site.pp"
-manifest instead for node classification.
+```
+    gem install master_manipulator
+```
 
-#### Example
-
-    disable_node_classifier(master)
-
-### disable_env_cache
-
-Disable environment caching on a Puppet Enterprise master to allow for dynamic
-updates to environments without waiting for cache purge.
-
-#### Example
-
-    disable_env_cache(master)
-
-### restart_puppet_server
-
-Restart the Puppet Server service to pickup configuration changes made to the
-"puppet.conf" file.
-
-#### Example
-
-Restart the Puppet Server service on Puppet Enterprise:
-
-    restart_puppet_server(master)
-
-### get_manifests_path
-
-Retrieve the path to the manifests folder for an environment on a master.
-
-#### Example 1
-
-Retrieve the path to the manifests folder for the "production" environment.
-
-    prod_env_manifests_path = get_manifests_path(master)
-
-#### Example 2
-
-Retrieve the path to the manifests folder for the "staging" environment.
-
-    stage_env_manifests_path = get_manifests_path(master, :env => 'staging')
-
-### get_site_pp_path
-
-Retrieve the path to the "site.pp" manifest for an environment on a master.
-
-#### Example 1
-
-Retrieve the path to the "site.pp" manifest for the "production" environment.
-
-    prod_env_site_pp_path = get_site_pp_path(master)
-
-#### Example 2
-
-Retrieve the path to the "site.pp" manifest for the "production" environment.
-
-    stage_env_site_pp_path = get_site_pp_path(master, :env => 'staging')
-
-### create_site_pp
-
-Create a "site.pp" file with file bucket enabled. Also, allow the creation of a
-custom node definition or use the 'default' node definition.
-
-#### Example 1
-
-Create a "site.pp" manifest with the default node definition using a simple
-manifest.
-
-    site_pp = create_site_pp(master, :manifest => 'notify { hello: }')
-
-#### Example 2
-
-Create a "site.pp" manifest with a custom node definition using a simple
-manifest.
-
-    site_pp = create_site_pp(master, :node_def_name => 'puppet_agent', :manifest => 'notify { hello: }')
-
-### set_perms_on_remote
-
-Set permissions and ownership on a remote file.
-
-#### Example 1
-
-Set permissions on the "site.pp" manifest with default ownership of Pupppet
-user and group.
-
-    set_perms_on_remote(master, get_site_pp_path(master), '644')
-
-#### Example 2
-
-Set permissions on the "site.pp" manifest with root ownership.
-
-    set_perms_on_remote(master, get_site_pp_path(master), '644', :owner => 'root', :group => 'root')
-
-### inject_site_pp
-
-Inject a "site.pp" manifest onto a master.
-
-#### Example
-
-    prod_env_site_pp_path = get_site_pp_path(master)
-    site_pp = create_site_pp(master, :manifest => 'notify { hello: }')
-    inject_site_pp(master, prod_env_site_pp_path, site_pp)
+Refer to [the API document](doc/apiref.md) for API information.

--- a/doc/apiref.md
+++ b/doc/apiref.md
@@ -1,0 +1,126 @@
+# Master Manipulator API Summary, v1.2.4
+
+Before trying to use the APIs described in this document, please
+make sure you have installed the Master Manipulator gem as described
+in the top-level [README.md](../README.md). As the name implies,
+this document is a high-level description of each Master Manipulator
+(_MM_ henceforth) API call, the method signature, and a simple
+example. Read this if you are impatient and just want to start
+slinging code. Complete documentation is maintained in YARD.
+
+## Methods
+
+### `disable_node_classifier(host)`
+
+Disables the node classifier on a PE master and use the $PUPPETDIR/site.pp
+manifest instead for node classification.
+
+* Disable the node classifier on master:
+
+    ```
+    disable_node_classifier(master)
+    ```
+
+### `disable_env_cache(host)`
+
+Disables environment caching on a PE master to allow dynamic updates
+to environments without waiting for cache purge.
+
+* Disable the environment cache master:
+
+    ```
+    disable_env_cache(master)
+    ```
+
+### `restart_puppet_server(host)`
+
+Restarts the puppetserver service to pickup configuration changes
+made to puppet.conf or other configuration files. *NOTE* This stops
+and restarts puppetserver, which is a slow process compared to
+simply _reloading_ puppetserver, which issues a HUP to the puppetserver
+process to force reloading configuration files. See
+[`reload_puppetserver`]().
+
+* Restart puppetserver on the master:
+
+    ```
+    restart_puppet_server(master)
+    ```
+
+### `get_manifests_path`
+
+Returns the path to the manifests folder for an environment on a
+master.
+
+* Retrieve the path to the manifests folder for the production environment:
+
+    ```
+    prod_env_manifests_path = get_manifests_path(master)
+    ```
+
+* Retrieve the path to the manifests folder for the staging environment:
+
+    ```
+    stage_env_manifests_path = get_manifests_path(master, :env => 'staging')
+    ```
+
+### `get_site_pp_path`
+
+Returns the path to the site.pp manifest for an environment on a
+master.
+  
+* Retrieve the path to the site.pp manifest for the production environment:
+
+    ```
+    prod_env_site_pp_path = get_site_pp_path(master)
+    ```
+* Retrieve the path to the site.pp manifest for the production environment.
+
+    ```
+    stage_env_site_pp_path = get_site_pp_path(master, :env => 'staging')
+    ```
+
+### `create_site_pp`
+
+Creates a site.pp file with file bucket enabled. Supports the
+creation of a custom node definition or use the 'default' node
+definition.
+
+* Create a site.pp manifest with the default node definition using a simple manifest:
+
+    ```
+    site_pp = create_site_pp(master, :manifest => 'notify { hello: }')
+    ```
+* Create a site.pp manifest with a custom node definition using a simple manifest:
+
+    ```
+    site_pp = create_site_pp(master, :node_def_name => 'puppet_agent', :manifest => 'notify { hello: }')
+    ```
+
+### `set_perms_on_remote`
+
+Sets permissions and ownership on a remote file.
+
+* Set permissions on the site.pp manifest with default ownership of Puppet user and group.
+
+    ```
+    set_perms_on_remote(master, get_site_pp_path(master), '644')
+    ```
+
+* Set permissions on the site.pp manifest with root ownership:
+
+    ```
+    set_perms_on_remote(master, get_site_pp_path(master), '644', :owner => 'root', :group => 'root')
+    ```
+    
+### `inject_site_pp`
+
+Injects a site.pp manifest onto a master.
+
+* Inject a site.pp manifest onto master
+
+    ```
+    prod_env_site_pp_path = get_site_pp_path(master)
+    site_pp = create_site_pp(master, :manifest => 'notify { hello: }')
+    inject_site_pp(master, prod_env_site_pp_path, site_pp)
+    ```


### PR DESCRIPTION
Separate the general, top-level README from the API references. These changes are prep work for a 2.0 release, but this could be pushed out in a new gem as 1.2.5.