### PR TITLE
(maint) Fix YARD markup; modify a couple of variable names

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 # default - History
 ## Tags
-* [LATEST - 27 Sep, 2016 (036a99e6)](#LATEST)
+* [LATEST - 06 Jan, 2016 (36910dd)](#LATEST)
+* [1.2.4 - 27 Sep, 2016 (036a99e6)](#1.2.4)
 * [1.2.3 - 20 Nov, 2015 (f31e884e)](#1.2.3)
 * [1.2.2 - 30 Oct, 2015 (31450d3c)](#1.2.2)
 * [1.2.1 - 30 Oct, 2015 (b59fd2cf)](#1.2.1)
@@ -12,7 +13,28 @@
 * [1.0.0 - 6 May, 2015 (8ae50d90)](#1.0.0)
 
 ## Details
-### <a name = "LATEST">LATEST - 27 Sep, 2016 (036a99e6)
+### <a name = "LATEST">LATEST - 06 Jan, 2016 (36910dd)
+* Fix spec failures (36910dd)
+
+* Various cleanups ahead of a 1.2.5 release (fdf54a2)
+
+* Merge pull request #22 from kurtwall/seed-the-yard (49f6ca5)
+
+* Merge https://github.com/puppetlabs/master_manipulator into seed-the-yard (38cb146)
+
+* Merge pull request #21 from kurtwall/update-readme (1d75e90)
+
+* Start the initial conversion to YARD (169b575)
+
+* Update README.md (2159ad7)
+
+* (QA-2789) Revise Master Manipulator docs (fc5cae8)
+
+* Merge pull request #20 from kurtwall/fix-typo (eff5cdf)
+
+* (MAINT) Fix typo (d3a6306)
+
+### <a name = "1.2.4">1.2.4 - 27 Sep, 2016 (036a99e6)
 
 * (GEM) update master_manipulator version to 1.2.4 (036a99e6)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-
 # Master Manipulator
 
 This gem extends the Beaker DSL for the purpose of changing things on a
-Puppet master.
+Puppet master
 
 ## Installation
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
 require "bundler/gem_tasks"
-
 require 'rspec/core/rake_task'
 
 task :default => :test

--- a/doc/apiref.md
+++ b/doc/apiref.md
@@ -1,4 +1,4 @@
-# Master Manipulator API Summary, v1.2.4
+# Master Manipulator API Summary, v1
 
 Before trying to use the APIs described in this document, please
 make sure you have installed the Master Manipulator gem as described
@@ -47,7 +47,7 @@ process to force reloading configuration files. See
     restart_puppet_server(master)
     ```
 
-### `get_manifests_path`
+### `get_manifests_path(host)`
 
 Returns the path to the manifests folder for an environment on a
 master.
@@ -64,7 +64,7 @@ master.
     stage_env_manifests_path = get_manifests_path(master, :env => 'staging')
     ```
 
-### `get_site_pp_path`
+### `get_site_pp_path(host)`
 
 Returns the path to the site.pp manifest for an environment on a
 master.
@@ -80,7 +80,7 @@ master.
     stage_env_site_pp_path = get_site_pp_path(master, :env => 'staging')
     ```
 
-### `create_site_pp`
+### `create_site_pp(host, manifest)`
 
 Creates a site.pp file with file bucket enabled. Supports the
 creation of a custom node definition or use the 'default' node
@@ -97,7 +97,7 @@ definition.
     site_pp = create_site_pp(master, :node_def_name => 'puppet_agent', :manifest => 'notify { hello: }')
     ```
 
-### `set_perms_on_remote`
+### `set_perms_on_remote(host, path, mode)`
 
 Sets permissions and ownership on a remote file.
 
@@ -113,7 +113,7 @@ Sets permissions and ownership on a remote file.
     set_perms_on_remote(master, get_site_pp_path(master), '644', :owner => 'root', :group => 'root')
     ```
     
-### `inject_site_pp`
+### `inject_site_pp(host, path, manifest)`
 
 Injects a site.pp manifest onto a master.
 

--- a/lib/master_manipulator/config.rb
+++ b/lib/master_manipulator/config.rb
@@ -1,19 +1,24 @@
 module MasterManipulator
   module Config
 
-    # Disable the Node Classifier on the Puppet master
-    # @param master_host [Beaker::Host] the master running Puppet Server.
-    # @return Nothing
-    # @example site_pp = disable_node_classifier(master_host)
+    # Disable the node classifier on the Puppet master
+    # @param [Beaker::Host] master_host The master running the Puppet server.
+    # @return nil
+    # @example Disable the node classifier on the master
+    #   disable_node_classifier(master)
+    #   reload_puppetserver(master)
     def disable_node_classifier(master_host)
       on(master_host, puppet('config set node_terminus plain --section master'))
     end
 
     # Disable environment caching on the Puppet master. Modifying this
-    # this setting requires a reload or restart of puppetserver.
-    # @param master_host [Beaker::Host] the master running puppetserver
-    # @return Nothing
-    # @example site_pp = disable_node_classifier(master_host)
+    # this setting requires reloading (preferred) or restarting (not
+    # preferred) the Puppet server
+    # @param [Beaker::Host] master_host The master running the Puppet server.
+    # @return nil
+    # @example Disable the environment cache on master
+    #   disable_env_cache(master)
+    #   reload_puppetserver(master)
     def disable_env_cache(master_host)
       on(master_host, puppet('config set environment_timeout 0 --section main'))
     end

--- a/lib/master_manipulator/service.rb
+++ b/lib/master_manipulator/service.rb
@@ -3,29 +3,34 @@ require 'json'
 module MasterManipulator
   module Service
 
-    # Restart the puppet server and wait for it to come back up.
-    # Raises a standard error if the wait is unsuccessful
-    # ==== Attributes
-    # @param [Beaker::Host] host the host that this should operate on
-    # @param [Hash] opts an optional options hash
-    #   *+:wait_cycles+ - the number of cycles to attempt retry
-    #   *+:is_pe?+ - Boolean : if the SUT is PE, defaults to true
-    # @return Nothing
-    # @example restart_puppet_server(master)
-    # @example restart_puppet_server(master, {:wait_cycles => 20})
-    def restart_puppet_server(host, opts = {})
+    # Restart the puppet server and wait for it to come back up or raise
+    # an error if the wait times out
+    # @param [Beaker::Host] master_host The host to manipulate.
+    # @param [Hash] opts Optional options hash containing options
+    # @option opts [Boolean] :is_pe? true if host is running PE, false otherwise
+    # @option opts [Integer] :wait_cycles How many attempt to make before failing
+    # @return nil
+    # @example Restart the puppetserver process on a PE master
+    #   restart_puppet_server(master)
+    # @example Restart the puppetserver process on a FOSS master
+    #   restart_puppet_server(master, {:is_pe? => false})
+    # @example Restart the puppetserver process on a PE master, timing out after 20 attempts
+    #   restart_puppet_server(master, {:wait_cycles => 20})
+    # @example Restart the puppetserver process on a FOSS master, timing out after 20 attempts
+    #   restart_puppet_server(master, {:is_pe? => false, :wait_cycles => 20})
+    def restart_puppet_server(master_host, opts = {:is_pe? => true, :wait_cycles => 10})
 
       start_time = Time.now
 
-      opts[:is_pe?] ||= true
+      # opts[:is_pe?] ||= true
       opts[:is_pe?] ? service_name = 'pe-puppetserver' : service_name = 'puppetserver'
 
-      on(host, puppet("resource service #{service_name} ensure=stopped"))
-      on(host, puppet("resource service #{service_name} ensure=running"))
-      hostname = on(host, 'hostname').stdout.chomp
+      on(master_host, puppet("resource service #{service_name} ensure=stopped"))
+      on(master_host, puppet("resource service #{service_name} ensure=running"))
+      hostname = on(master_host, 'hostname').stdout.chomp
       opts[:wait_cycles] ||= 10
 
-      pe_ver = pe_version(host)
+      pe_ver = pe_version(master_host)
       three_eight_regex = /^3\.8/
 
       # This logic is not ideal refactor in the future
@@ -38,7 +43,7 @@ module MasterManipulator
       end
 
       (1..opts[:wait_cycles]).each do |i|
-        @result = curl_on(host, curl_call, :acceptable_exit_codes => [0,1,7])
+        @result = curl_on(master_host, curl_call, :acceptable_exit_codes => [0,1,7])
         # parse body if we are using PE and we are not in PE 3.8
         (pe_ver && !pe_ver.match(three_eight_regex)) ? @body = JSON.parse(@result.stdout) : @body = []
 
@@ -47,14 +52,14 @@ module MasterManipulator
             sleep 20
             pe_ver.match(/three_eight_regex/) ? return : (return if @body.all? { |k, v| v['state'] == 'running' })
           when '1', '7'
-            # Exit code 7 is "connection refused"
+            # Exit code 7 is 'connection refused'
             sleep (i**(1.2))
         end
       end
 
       total_time = Time.now - start_time
       message = "Attempted to restart #{opts[:wait_cycles]} times, waited #{total_time} seconds total."
-      message << "\nHere is the status reported by the puppetserver'"
+      message << "\nHere is the status reported by the puppetserver"
 
       @body.each do |k,v|
         message << "\n'#{k}' state: #{v['state']} "
@@ -63,15 +68,16 @@ module MasterManipulator
 
     end
 
-    # Determine the version of PE installed on the master
-    # @param [Beaker::Host] host the host that this should operate on
-    # @return [String] the version of puppet enterprise, if version can not be determined 'version unknown' is returned
-    # ver = pe_version
-    def pe_version(host)
-      if on(host, 'test -f /opt/puppet/pe_version', :acceptable_exit_codes => [0,1]).exit_code == 0
-        return on(host, 'cat /opt/puppet/pe_version').stdout.chomp
-      elsif on(host, 'test -f /opt/puppetlabs/server/pe_version', :acceptable_exit_codes => [0,1]).exit_code == 0
-        return on(host, 'cat /opt/puppetlabs/server/pe_version').stdout.chomp
+    # Return the version of PE installed on the specified Puppet master
+    # @param [Beaker::Host] master_host the master to query.
+    # @return [String] The version of Puppet Enterprise, or 'version unknown' if undetermined
+    # @example Return the version of PE running on master
+    #   ver = pe_version(master)
+    def pe_version(master_host)
+      if on(master_host, 'test -f /opt/puppet/pe_version', :acceptable_exit_codes => [0,1]).exit_code == 0
+        return on(master_host, 'cat /opt/puppet/pe_version').stdout.chomp
+      elsif on(master_host, 'test -f /opt/puppetlabs/server/pe_version', :acceptable_exit_codes => [0,1]).exit_code == 0
+        return on(master_host, 'cat /opt/puppetlabs/server/pe_version').stdout.chomp
       else
         return 'version unknown'
       end

--- a/lib/master_manipulator/service.rb
+++ b/lib/master_manipulator/service.rb
@@ -18,11 +18,11 @@ module MasterManipulator
     #   restart_puppet_server(master, {:wait_cycles => 20})
     # @example Restart the puppetserver process on a FOSS master, timing out after 20 attempts
     #   restart_puppet_server(master, {:is_pe? => false, :wait_cycles => 20})
-    def restart_puppet_server(master_host, opts = {:is_pe? => true, :wait_cycles => 10})
+    def restart_puppet_server(master_host, opts = {})
 
       start_time = Time.now
 
-      # opts[:is_pe?] ||= true
+      opts[:is_pe?] ||= true
       opts[:is_pe?] ? service_name = 'pe-puppetserver' : service_name = 'puppetserver'
 
       on(master_host, puppet("resource service #{service_name} ensure=stopped"))

--- a/lib/master_manipulator/site.rb
+++ b/lib/master_manipulator/site.rb
@@ -10,7 +10,8 @@ module MasterManipulator
     #   prod_env_manifests_path = get_manifests_path(master)
     # @example Get the manifests path for the testing environment on master
     #   test_env_manifests_path = get_manifests_path(master, {:env => 'test'})
-    def get_manifests_path(master_host, opts = {:env => 'production'})
+    def get_manifests_path(master_host, opts = {})
+      opts[:env] ||= 'production'
       environment_base_path = on(master_host, puppet('config print environmentpath')).stdout.rstrip
 
       return File.join(environment_base_path, opts[:env], 'manifests')
@@ -25,7 +26,8 @@ module MasterManipulator
     #   prod_env_site_pp_path = get_site_pp_path(master)
     # @example Return the path to the site.pp file for the testing environment on master
     #   prod_env_site_pp_path = get_site_pp_path(master, {:env => 'testing'})
-    def get_site_pp_path(master_host, opts = {:env => 'production'})
+    def get_site_pp_path(master_host, opts = {})
+      opts[:env] ||= 'production'
 
       return File.join(get_manifests_path(master_host, opts), 'site.pp')
     end
@@ -44,7 +46,9 @@ module MasterManipulator
     #   site_pp = create_site_pp(master, {:node_def_name => 'mailgrunt'})
     # @example Create a site.pp on master for a node named 'mailgrunt' with a custom node definition in the manifest
     #   site_pp = create_site_pp(master, {:manifest => manifest_for_mailgrunt, :node_def_name => 'mailgrunt'})
-    def create_site_pp(master_host, opts = {:manifest => '', :node_def_name => 'default'})
+    def create_site_pp(master_host, opts = {})
+      opts[:manifest] ||= ''
+      opts[:node_def_name] ||= 'default'
       master_certname = on(master_host, puppet('config print certname')).stdout.rstrip
 
       default_def = <<-MANIFEST
@@ -92,7 +96,7 @@ MANIFEST
     #   set_perms_on_remote(master, '/tmp/this_is_junk.pp', '0644', {:user => 'tommy')
     # @example Set perms on a file on master with a custom user and a custom group
     #   set_perms_on_remote(master, '/tmp/this_is_junk.pp', '0644', {:user => 'tommy', :group => 'tutones')
-    def set_perms_on_remote(master_host, path, mode, opts = {:owner => 'puppet', :group => 'puppet'})
+    def set_perms_on_remote(master_host, path, mode, opts = {})
       opts[:owner] ||= on(master_host, puppet('config print user')).stdout.rstrip
       opts[:group] ||= on(master_host, puppet('config print group')).stdout.rstrip
 

--- a/lib/master_manipulator/site.rb
+++ b/lib/master_manipulator/site.rb
@@ -2,39 +2,49 @@ module MasterManipulator
   module Site
 
     # Get the location of an environment's manifests path; defaults to production environment.
-    # @param [Beaker::Host] master_host The master host that contains environments
-    # @param [Hash] opts:env The environment from which to discover the manifests path
-    # @return [String] An absolute path to the manifests for an environment on the master host
-    # @example prod_env_manifests_path = get_manifests_path(master)
-    def get_manifests_path(master_host, opts = {})
-      opts[:env] ||= 'production'
+    # @param [Beaker::Host] master_host The master host that contains environments.
+    # @param [Hash] opts Optional options hash containing options.
+    # @option opts [String] :env The environment to query on the specified master
+    # @return [String] The absolute path to the manifests for the given environment on the given master
+    # @example Get the manifests path for the production environment on master
+    #   prod_env_manifests_path = get_manifests_path(master)
+    # @example Get the manifests path for the testing environment on master
+    #   test_env_manifests_path = get_manifests_path(master, {:env => 'test'})
+    def get_manifests_path(master_host, opts = {:env => 'production'})
       environment_base_path = on(master_host, puppet('config print environmentpath')).stdout.rstrip
 
       return File.join(environment_base_path, opts[:env], 'manifests')
     end
 
-    # Get the location of an environment's site.pp path. Defaults to production environment
-    # @param [Beaker::Host] master_host The master host that contains environments
-    # @param [Hash] opts:env The environment from which to discover the site.pp path
-    # @return [String] An absolute path to the site.pp for an environment on the master host
-    # @example prod_env_site_pp_path = get_site_pp_path(master)
-    def get_site_pp_path(master_host, opts = {})
-      opts[:env] ||= 'production'
+    # Get the path to a given environment's site.pp; defaults to production environment.
+    # @param [Beaker::Host] master_host The master to query.
+    # @param [Hash] opts Optional options hash containing options.
+    # @option opts [String] :env opts The environment to query on the specified master
+    # @return [String] The absolute path to the site.pp for the given environment on the given master
+    # @example Return the path to the site.pp file for the production environment on master
+    #   prod_env_site_pp_path = get_site_pp_path(master)
+    # @example Return the path to the site.pp file for the testing environment on master
+    #   prod_env_site_pp_path = get_site_pp_path(master, {:env => 'testing'})
+    def get_site_pp_path(master_host, opts = {:env => 'production'})
 
       return File.join(get_manifests_path(master_host, opts), 'site.pp')
     end
 
-    # Create a "site.pp" file with file bucket enabled. Also, allow
+    # Create a site.pp file with file bucket enabled. Also, allow
     # the creation of a custom node definition or use the default
     # node definition.
-    # @param [Beaker::Host] master_host the target master for "site.pp" injection
-    # @param [Hash] opts:manifest a Puppet manifest to inject into the node definition
-    # @param [Hash] opts:node_def_name a node definition pattern or name
-    # @return [String] manifest a combined manifest with node definition containing input manifest
-    # @example site_pp = create_site_pp(master, '', node_def_name='agent')
-    def create_site_pp(master_host, opts = {})
-      opts[:manifest] ||= ''
-      opts[:node_def_name] ||= 'default'
+    # @param [Beaker::Host] master_host the target master for site.pp injection.
+    # @param [Hash] opts Optional options hash containing options.
+    # @option opts [String] :manifest The node definition to lay down
+    # @option opts [String] :node_def_name The node definition name
+    # @return [String] manifest A manifest containing the input node definition to lay down in site.pp
+    # @example Create a site.pp on master using the default node definition and an otherwise empty manifest
+    #   site_pp = create_site_pp(master)
+    # @example Create a site.pp on master for a node named 'mailgrunt' with an otherwise empty manifest
+    #   site_pp = create_site_pp(master, {:node_def_name => 'mailgrunt'})
+    # @example Create a site.pp on master for a node named 'mailgrunt' with a custom node definition in the manifest
+    #   site_pp = create_site_pp(master, {:manifest => manifest_for_mailgrunt, :node_def_name => 'mailgrunt'})
+    def create_site_pp(master_host, opts = {:manifest => '', :node_def_name => 'default'})
       master_certname = on(master_host, puppet('config print certname')).stdout.rstrip
 
       default_def = <<-MANIFEST
@@ -67,32 +77,41 @@ MANIFEST
     end
 
     # Set mode, owner and group on a remote path.
-    # @param [Beaker::Host] host the remote host containing the target path.
-    # @param [String] path the path to set mode, user and group upon.
-    # @param [String] mode the desired mode to set on the path in as a string.
-    # @param [Hash] opts:owner the owner to set on the path; defaults to puppet user
-    # @param [Hash] opts:group the group to set on the path; defulats to puppet group
+    # @param [Beaker::Host] master_host The remote host containing the target path.
+    # @param [String] path The pathname on which to set mode, user and group.
+    # @param [String] mode The desired file mode in 4-digit octal string (e.g. '0644').
+    # @param [Hash] opts Optional options hash containing options.
+    # @option opts [String] :owner The user owner to assign
+    # @option opts [String] :group The group owner to assign
     # @return nil
-    # @example set_perms_on_remote(master, "/tmp/test/site.pp", "777")
-    def set_perms_on_remote(host, path, mode, opts = {})
-      opts[:owner] ||= on(host, puppet('config print user')).stdout.rstrip
-      opts[:group] ||= on(host, puppet('config print group')).stdout.rstrip
+    # @example Set perms on a file on master with the default user and group
+    #   set_perms_on_remote(master, '/tmp/this_is_junk.pp', '0644')
+    # @example Set perms on a file on master with the default user and a custom group
+    #   set_perms_on_remote(master, '/tmp/this_is_junk.pp', '0644', {:group => 'tutones')
+    # @example Set perms on a file on master with a custom user and the default group
+    #   set_perms_on_remote(master, '/tmp/this_is_junk.pp', '0644', {:user => 'tommy')
+    # @example Set perms on a file on master with a custom user and a custom group
+    #   set_perms_on_remote(master, '/tmp/this_is_junk.pp', '0644', {:user => 'tommy', :group => 'tutones')
+    def set_perms_on_remote(master_host, path, mode, opts = {:owner => 'puppet', :group => 'puppet'})
+      opts[:owner] ||= on(master_host, puppet('config print user')).stdout.rstrip
+      opts[:group] ||= on(master_host, puppet('config print group')).stdout.rstrip
 
-      on(host, "chmod -R #{mode} #{path}")
-      on(host, "chown -R #{opts[:owner]}:#{opts[:group]} #{path}")
+      on(master_host, "chmod -Rv #{mode} #{path}")
+      on(master_host, "chown -Rv #{opts[:owner]}:#{opts[:group]} #{path}")
     end
 
-    # Inject a "site.pp" manifest onto a master.
+    # Inject a site.pp manifest onto a master.
     # @param [Beaker::Host] master_host the target master for injection.
     # @param [String] site_pp_path a path on the remote host into which the site.pp will be injected.
-    # @param [String] manifest the manifest content to inject into "site.pp" to the host target path.
+    # @param [String] manifest the manifest content to inject into site.pp to the host target path.
     # @return nil
-    # @example site_pp = inject_site_pp(master_host, "/tmp/test/site.pp", manifest)
+    # @example Place this_is_junk.pp, with the contents defined in manifest, in /tmp on the master named compile_master
+    #   site_pp = inject_site_pp(compile_master, '/tmp/this_is_junk.pp', manifest)
     def inject_site_pp(master_host, site_pp_path, manifest)
       site_pp_dir = File.dirname(site_pp_path)
       create_remote_file(master_host, site_pp_path, manifest)
 
-      set_perms_on_remote(master_host, site_pp_dir, '744')
+      set_perms_on_remote(master_host, site_pp_dir, '0744')
     end
 
   end

--- a/master_manipulator.gemspec
+++ b/master_manipulator.gemspec
@@ -6,10 +6,10 @@ require 'master_manipulator/version'
 Gem::Specification.new do |spec|
   spec.name          = 'master_manipulator'
   spec.version       = MasterManipulator::Version::STRING
-  spec.authors       = ['Puppet Labs']
-  spec.email         = ['qa@puppetlabs.com']
-  spec.summary       = 'Puppet Labs testing library for controlling a Puppet Master'
-  spec.description   = 'This Gem extends the Beaker DSL for the purpose of changing things on a Puppet Master.'
+  spec.authors       = ['Puppet, Inc.']
+  spec.email         = ['qa@puppet.com']
+  spec.summary       = 'Puppet test library for modifying a Puppet master'
+  spec.description   = 'This gem extends the Beaker DSL for the purpose of changing things on a Puppet master'
   spec.homepage      = 'https://github.com/puppetlabs/master_manipulator'
   spec.license       = 'Apache-2.0'
   spec.files         = Dir['[A-Z]*[^~]'] + Dir['lib/**/*.rb'] + Dir['spec/*']
@@ -29,5 +29,4 @@ Gem::Specification.new do |spec|
   # Run time dependencies
   spec.add_runtime_dependency 'beaker', '>= 2.7.0'
   spec.add_runtime_dependency 'multi_json'
-
 end


### PR DESCRIPTION
Fix a couple of mistakes in the initial conversion to YARD. In the process, it was helpful to change a couple of variable names to make the documentation clearer.