### PR TITLE
(QA-2812) API ref missing #pe_version method

### DIFF
--- a/doc/apiref.md
+++ b/doc/apiref.md
@@ -10,6 +10,23 @@ slinging code. Complete documentation is maintained in YARD.
 
 ## Methods
 
+### `create_site_pp(host, manifest)`
+
+Creates a site.pp file with file bucket enabled. Supports the
+creation of a custom node definition or use the 'default' node
+definition.
+
+* Create a site.pp manifest with the default node definition using a simple manifest:
+
+    ```
+    site_pp = create_site_pp(master, :manifest => 'notify { hello: }')
+    ```
+* Create a site.pp manifest with a custom node definition using a simple manifest:
+
+    ```
+    site_pp = create_site_pp(master, :node_def_name => 'puppet_agent', :manifest => 'notify { hello: }')
+    ```
+
 ### `disable_node_classifier(host)`
 
 Disables the node classifier on a PE master and use the $PUPPETDIR/site.pp
@@ -30,21 +47,6 @@ to environments without waiting for cache purge.
 
     ```
     disable_env_cache(master)
-    ```
-
-### `restart_puppet_server(host)`
-
-Restarts the puppetserver service to pickup configuration changes
-made to puppet.conf or other configuration files. *NOTE* This stops
-and restarts puppetserver, which is a slow process compared to
-simply _reloading_ puppetserver, which issues a HUP to the puppetserver
-process to force reloading configuration files. See
-[`reload_puppetserver`]().
-
-* Restart puppetserver on the master:
-
-    ```
-    restart_puppet_server(master)
     ```
 
 ### `get_manifests_path(host)`
@@ -80,21 +82,40 @@ master.
     stage_env_site_pp_path = get_site_pp_path(master, :env => 'staging')
     ```
 
-### `create_site_pp(host, manifest)`
+### `inject_site_pp(host, path, manifest)`
 
-Creates a site.pp file with file bucket enabled. Supports the
-creation of a custom node definition or use the 'default' node
-definition.
+Injects a site.pp manifest onto a master.
 
-* Create a site.pp manifest with the default node definition using a simple manifest:
+* Inject a site.pp manifest onto master
 
     ```
+    prod_env_site_pp_path = get_site_pp_path(master)
     site_pp = create_site_pp(master, :manifest => 'notify { hello: }')
+    inject_site_pp(master, prod_env_site_pp_path, site_pp)
     ```
-* Create a site.pp manifest with a custom node definition using a simple manifest:
+
+### `pe_version(master)`
+
+Returns the version of PE installed on the specified Puppet master as a string
+
+* Return the version of PE running on master
+    ```
+    ver = pe_version(master)
+    ```
+
+### `restart_puppet_server(host)`
+
+Restarts the puppetserver service to pickup configuration changes
+made to puppet.conf or other configuration files. *NOTE* This stops
+and restarts puppetserver, which is a slow process compared to
+simply _reloading_ puppetserver, which issues a HUP to the puppetserver
+process to force reloading configuration files. See
+[`reload_puppetserver`]().
+
+* Restart puppetserver on the master:
 
     ```
-    site_pp = create_site_pp(master, :node_def_name => 'puppet_agent', :manifest => 'notify { hello: }')
+    restart_puppet_server(master)
     ```
 
 ### `set_perms_on_remote(host, path, mode)`
@@ -113,14 +134,3 @@ Sets permissions and ownership on a remote file.
     set_perms_on_remote(master, get_site_pp_path(master), '644', :owner => 'root', :group => 'root')
     ```
     
-### `inject_site_pp(host, path, manifest)`
-
-Injects a site.pp manifest onto a master.
-
-* Inject a site.pp manifest onto master
-
-    ```
-    prod_env_site_pp_path = get_site_pp_path(master)
-    site_pp = create_site_pp(master, :manifest => 'notify { hello: }')
-    inject_site_pp(master, prod_env_site_pp_path, site_pp)
-    ```


### PR DESCRIPTION
- Add a summary for the `#pe_version` instance method
- Alphabetize the method list for easy parsing