### PR TITLE
DO NOT MERGE Add .reload_puppet_server and some spec tests DO NOT MERGE

### DIFF
--- a/lib/master_manipulator/service.rb
+++ b/lib/master_manipulator/service.rb
@@ -3,6 +3,72 @@ require 'json'
 module MasterManipulator
   module Service
 
+    # Reload puppetserver on the specified host and wait for it to come
+    # back up or raise an error. This method reloads the puppetserver configuration
+    # files and calls HUP on the puppetserver process. It does not stop and restart
+    # puppetserver (see #restart_puppet_server).
+    # @param [Beaker::Host] master_host The host to manipulate.
+    # @param [Hash] opts Optional options hash containing options
+    # @option opts [Boolean] :is_pe? true if host is running PE, false otherwise
+    # @option opts [Integer] :wait_cycles How many attempt to make before failing
+    # @return nil
+    # @example Reload the puppetserver process on a PE master
+    #   reload_puppet_server(master)
+    # @example Reload the puppetserver process on a FOSS master
+    #   reload_puppet_server(master, {:is_pe? => false})
+    # @example Reload the puppetserver process on a PE master, timing out after 20 attempts
+    #   reload_puppet_server(master, {:wait_cycles => 20})
+    # @example Reload the puppetserver process on a FOSS master, timing out after 20 attempts
+    #   reload_puppet_server(master, {:is_pe? => false, :wait_cycles => 20})
+    def reload_puppet_server(master_host, opts = {})
+
+      start_time = Time.now
+      opts[:wait_cycles] ||= 10
+
+      opts[:is_pe?] ||= true
+      service_name = opts[:is_pe?] ? 'pe-puppetserver' : 'puppetserver'
+
+      on(master_host, "#{service_name} reload")
+      hostname = master_host.puppet['certname']
+
+      pe_ver = pe_version(master_host)
+      three_eight_regex = /^3\.8/
+
+      # This logic is not ideal refactor in the future
+      # if its PE and not 3.8 use the status endpoint
+      # it its not PE or it is 3.8 use the simple curl call
+      if pe_ver && !pe_ver.match(three_eight_regex)
+        curl_call = "-k -X GET -H 'Content-Type: application/json' https://#{hostname}:8140/status/v1/services?level=debug"
+      else
+        curl_call = "-I -k https://#{hostname}:8140"
+      end
+
+      (1..opts[:wait_cycles]).each do |i|
+        @result = curl_on(master_host, curl_call, :acceptable_exit_codes => [0,1,7])
+        # parse body if we are using PE and we are not in PE 3.8
+        @body = (pe_ver && !pe_ver.match(three_eight_regex)) ? JSON.parse(@result.stdout) : []
+
+        case @result.exit_code.to_s
+          when '0'
+            sleep 20
+            pe_ver.match(/three_eight_regex/) ? return : (return if @body.all? { |k, v| v['state'] == 'running' })
+          when '1', '7'
+            # Exit code 7 is 'connection refused'
+            sleep (i**(1.2))
+        end
+      end
+
+      total_time = Time.now - start_time
+      message = "Attempted to restart #{opts[:wait_cycles]} times, waited #{total_time} seconds total."
+      message << "\nHere is the status reported by the puppetserver"
+
+      @body.each do |k,v|
+        message << "\n'#{k}' state: #{v['state']} "
+      end
+      raise message
+    end
+
+
     # Restart the puppet server and wait for it to come back up or raise
     # an error if the wait times out
     # @param [Beaker::Host] master_host The host to manipulate.

--- a/spec/master_manipulator/service_spec.rb
+++ b/spec/master_manipulator/service_spec.rb
@@ -97,6 +97,30 @@ describe MasterManipulator::Service do
       expect(dummy_class).to receive(:on).with(beaker_host, 'cat /opt/puppetlabs/server/pe_version').and_return(result)
     end
 
+    describe '.reload_puppet_server' do
+      let(:beaker_result) {
+        x = Beaker::Result.new('host', 'cmd')
+        x.stdout = successful_stdout
+        x.exit_code = 0
+        x
+      }
+
+      it 'with correct required argument' do
+        expect_pe_version
+        shared_dsl_expectations
+        expect(dummy_class).to receive(:curl_on).and_return(beaker_result)
+        expect{dummy_class.restart_puppet_server(beaker_host)}.not_to raise_error
+      end
+
+      it 'with too many arguments' do
+        expect{ dummy_class.restart_puppet_server(beaker_host, {}, 'nolo contendere') }.to raise_error(ArgumentError)
+      end
+
+      it 'with no arguments' do
+        expect{ dummy_class.restart_puppet_server }.to raise_error(ArgumentError)
+      end
+    end
+
     describe '.restart_puppet_server' do
 
       let(:beaker_result)       { x = Beaker::Result.new('host', 'cmd')


### PR DESCRIPTION
This commit adds support to tkhup to Master Manipulator as `reload_puppet_server`. Semantics are the same as `restart_puppet_server` except it only reloads not restarts puppetserver.