### PR TITLE
(QA-2827) added log rotation in a new module called log

### DIFF
--- a/doc/apiref.md
+++ b/doc/apiref.md
@@ -134,3 +134,15 @@ Sets permissions and ownership on a remote file.
     set_perms_on_remote(master, get_site_pp_path(master), '644', :owner => 'root', :group => 'root')
     ```
     
+
+### `rotate_puppet_server_log(host)`
+
+Performs a log file rotation on the puppetserver log file.  
+Intended to mimic what logback would do, which is a copy truncate.
+
+* Rotate the puppetserver log file on the master:
+
+    ```
+    rotate_puppet_server_log(master)
+    ```
+

--- a/lib/master_manipulator.rb
+++ b/lib/master_manipulator.rb
@@ -3,11 +3,12 @@ require 'beaker'
 
 module Beaker
   class TestCase
-    %w( config service site ).each do |lib|
+    %w( config service site log ).each do |lib|
       require "master_manipulator/#{lib}"
     end
     include MasterManipulator::Config
     include MasterManipulator::Service
     include MasterManipulator::Site
+    include MasterManipulator::Log
   end
 end

--- a/lib/master_manipulator/log.rb
+++ b/lib/master_manipulator/log.rb
@@ -1,0 +1,45 @@
+
+module MasterManipulator
+  module Log
+
+    #<fileNamePattern>/var/log/puppetlabs/puppetserver/puppetserver-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+
+    # Rollover the puppetserver log file the same way logback would
+    # @param [Beaker::Host] master_host The host to manipulate.
+    # @return nil
+    # @example Rollover the puppetserver log on a PE master
+    #   rotate_puppet_server_log(master)
+    def rotate_puppet_server_log(master_host)
+
+      log_dir = on(master_host, "puppet config print logdir").stdout.chomp
+      #this is ugly, rev 2 should parse the logback.xml, doesn't seem to be another way
+      log_file = log_dir + "server/puppetserver.log"
+
+      date_str = on(master_host, "date +%Y-%m-%d").stdout.chomp
+      backup_log_file = log_file.sub(/\log$/,date_str)
+
+      if ( on(master_host, "test -f #{log_file}",:accept_all_exit_codes => true).exit_code != 0 ) then
+        raise("Puppetserver log file missing: #{log_file}")
+      end
+
+      i = 0
+      max = 100
+      while (i < max) do 
+        if ( on(master_host, "test -f #{backup_log_file}.#{i}.log",:accept_all_exit_codes => true).exit_code == 1 ) then
+          backup_log_file = "#{backup_log_file}.#{i}.log"
+          break
+        end
+        i += 1
+      end
+      if ( i == max ) then
+        raise("Looks like #{max} puppetserver log rotations in one minute, more likely a code issue")
+      end
+      if ( on(master_host, "cp #{log_file} #{backup_log_file}; cat /dev/null > #{log_file}",:accept_all_exit_codes => true).exit_code != 0 ) then
+        raise("The copy truncate operation failed: cp #{log_file} #{backup_log_file}; cat /dev/null > #{log_file}");
+      end
+
+    end
+
+  end
+end
+

--- a/spec/master_manipulator/log_spec.rb
+++ b/spec/master_manipulator/log_spec.rb
@@ -1,0 +1,126 @@
+require 'spec_helper'
+require 'fileutils'
+
+describe MasterManipulator::Log do
+
+  let(:beaker_host)           { instance_double(Beaker::Host) }
+  let(:dummy_class)           { Class.new { extend MasterManipulator::Log} }
+#  let(:beaker_command)        { instance_double(Beaker::Command) }
+  let(:log_dir)               { "/tmp/MasterManipulator_Log/#{Process.pid}/puppetlabs/puppet" }
+  let(:log_dir_to_make)       { "/tmp/MasterManipulator_Log/#{Process.pid}/puppetlabs/puppetserver" }
+  let(:log_file)              { "/tmp/MasterManipulator_Log/#{Process.pid}/puppetlabs/puppetserver/puppetserver.log" }
+  let(:backup_log_file_base)  { "/tmp/MasterManipulator_Log/#{Process.pid}/puppetlabs/puppetserver/puppetserver.1976-07-04" }
+  let(:cmd_1)                 { 'puppet config print logdir' }
+  let(:cmd_test_log_file)     { "test -f #{log_file}" }
+  let(:cmd_date)              { "date +%Y-%m-%d" }
+  let(:cmd_test_backup_log_file_generic) { "test -f #{backup_log_file_base}.*" }
+  let(:cmd_test_backup_log_file_0) { "test -f #{backup_log_file_base}.0.log" }
+  let(:cmd_test_backup_log_file_1) { "test -f #{backup_log_file_base}.1.log*" }
+  let(:max_trys)              { 100 }
+
+
+  def shared_dsl_expectations
+    log_result = Beaker::Result.new('host', 'cmd')
+    log_result.stdout = log_dir
+    expect(dummy_class).to receive(:on).with(beaker_host, cmd_1).and_return(log_result)
+
+    date_result = Beaker::Result.new('host', 'cmd')
+    date_result.stdout = "1976-07-04"
+    expect(dummy_class).to receive(:on).with(beaker_host, cmd_date).and_return(date_result)
+  end
+  
+#add test for if log file is missing
+
+  context 'Normal' do 
+      
+    describe '.rotate_puppet_server_log' do
+      it 'With correct required argument' do
+        shared_dsl_expectations
+
+        log_file_test_result = Beaker::Result.new('host', 'cmd')
+        log_file_test_result.exit_code = 0
+        expect(dummy_class).to receive(:on).with(beaker_host, cmd_test_log_file, :accept_all_exit_codes => true).and_return(log_file_test_result)
+
+        backup_log_file_test_result = Beaker::Result.new('host', 'cmd')
+        backup_log_file_test_result.exit_code = 1
+        expect(dummy_class).to receive(:on).with(beaker_host, /#{cmd_test_backup_log_file_0}/,:accept_all_exit_codes => true ).and_return(backup_log_file_test_result)
+
+        copy_truncate_result = Beaker::Result.new('host', 'cmd')
+        copy_truncate_result.exit_code = 0
+        expect(dummy_class).to receive(:on).with(beaker_host,"cp #{log_file} #{backup_log_file_base}.0.log; cat /dev/null > #{log_file}",:accept_all_exit_codes => true).and_return(copy_truncate_result)
+
+        expect{dummy_class.rotate_puppet_server_log(beaker_host)}.not_to raise_error
+      end
+
+      it 'Backup already exists' do
+        shared_dsl_expectations
+
+        log_file_test_result = Beaker::Result.new('host', 'cmd')
+        log_file_test_result.exit_code = 0
+        expect(dummy_class).to receive(:on).with(beaker_host, cmd_test_log_file, :accept_all_exit_codes => true).and_return(log_file_test_result)
+
+        backup_log_file_0_test_result = Beaker::Result.new('host', 'cmd')
+        backup_log_file_0_test_result.exit_code = 0
+        expect(dummy_class).to receive(:on).with(beaker_host, /#{cmd_test_backup_log_file_0}/, :accept_all_exit_codes => true ).and_return(backup_log_file_0_test_result)
+      
+        backup_log_file_1_test_result = Beaker::Result.new('host', 'cmd')
+        backup_log_file_1_test_result.exit_code = 1
+        expect(dummy_class).to receive(:on).with(beaker_host, /#{cmd_test_backup_log_file_1}/, :accept_all_exit_codes => true ).and_return(backup_log_file_1_test_result)
+
+        copy_truncate_result = Beaker::Result.new('host', 'cmd')
+        copy_truncate_result.exit_code = 0
+        expect(dummy_class).to receive(:on).with(beaker_host,"cp #{log_file} #{backup_log_file_base}.1.log; cat /dev/null > #{log_file}", :accept_all_exit_codes => true).and_return(copy_truncate_result)
+
+        expect{dummy_class.rotate_puppet_server_log(beaker_host)}.not_to raise_error
+      end
+
+      it 'With too many arguments' do
+        expect{ dummy_class.rotate_puppet_server_log(beaker_host, {}, 'No Bueno') }.to raise_error(ArgumentError)
+      end
+
+      it 'With no arguments' do
+        expect{ dummy_class.rotate_puppet_server_log }.to raise_error(ArgumentError)
+      end
+      
+      it 'Log missing' do
+        shared_dsl_expectations
+        file_test_result = Beaker::Result.new('host', 'cmd')
+        file_test_result.exit_code = 1
+        expect(dummy_class).to receive(:on).with(beaker_host, cmd_test_log_file, :accept_all_exit_codes => true).and_return(file_test_result)
+        expect{ dummy_class.rotate_puppet_server_log(beaker_host) }.to raise_error(RuntimeError, /Puppetserver log file missing: #{log_file}/)
+      end
+
+      it 'Exceed max rotations per minute' do
+        shared_dsl_expectations
+
+        log_file_test_result = Beaker::Result.new('host', 'cmd')
+        log_file_test_result.exit_code = 0
+        expect(dummy_class).to receive(:on).with(beaker_host, cmd_test_log_file, :accept_all_exit_codes => true).and_return(log_file_test_result)
+
+        backup_log_file_test_result = Beaker::Result.new('host', 'cmd')
+        backup_log_file_test_result.exit_code = 0
+        expect(dummy_class).to receive(:on).with(beaker_host, /#{cmd_test_backup_log_file_generic}/, :accept_all_exit_codes => true ).exactly(max_trys).and_return(backup_log_file_test_result)
+        expect{dummy_class.rotate_puppet_server_log(beaker_host)}.to raise_error(RuntimeError, /Looks like #{max_trys} puppetserver log rotations in one minute, more likely a code issue/)
+      end
+
+      it 'Copy truncate fails' do
+        shared_dsl_expectations
+
+        log_file_test_result = Beaker::Result.new('host', 'cmd')
+        log_file_test_result.exit_code = 0
+        expect(dummy_class).to receive(:on).with(beaker_host, cmd_test_log_file, :accept_all_exit_codes => true).and_return(log_file_test_result)
+
+        backup_log_file_test_result = Beaker::Result.new('host', 'cmd')
+        backup_log_file_test_result.exit_code = 1
+        expect(dummy_class).to receive(:on).with(beaker_host, /#{cmd_test_backup_log_file_0}/, :accept_all_exit_codes => true ).and_return(backup_log_file_test_result)
+
+        copy_truncate_result = Beaker::Result.new('host', 'cmd')
+        copy_truncate_result.exit_code = 1
+        expect(dummy_class).to receive(:on).with(beaker_host,"cp #{log_file} #{backup_log_file_base}.0.log; cat /dev/null > #{log_file}", :accept_all_exit_codes => true).and_return(copy_truncate_result)
+
+        expect{dummy_class.rotate_puppet_server_log(beaker_host)}.to raise_error(RuntimeError, /The copy truncate operation failed: cp #{log_file} #{backup_log_file_base}.0.log; cat \/dev\/null > #{log_file}/)
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
(QA-2827) Simple logfile rotation that mimics what logback would do.  Used for clearing the log before a test that looks in the log file to safeguard from a possible rotation, and to remove anything from previous tests that might accidentally be interpreted as coming from the current test.

Note: I haven't done any acceptance testing yet. I actually haven't stopped to think about how to do that.  Figure I will work on that while this is reviewed for coding style and such.  Since this is my first I expect I did lots of things outside the norm. :)