### PR TITLE
(QA-2367) Add a .reload_puppet_server method and spec tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,6 @@ task :default => :test
 
 desc "Run spec tests"
 RSpec::Core::RakeTask.new(:test) do |t|
-  t.rspec_opts = ['--color']
+  t.rspec_opts = ['--color', '--format d']
   t.pattern = 'spec/'
 end

--- a/doc/apiref.md
+++ b/doc/apiref.md
@@ -103,6 +103,19 @@ Returns the version of PE installed on the specified Puppet master as a string
     ver = pe_version(master)
     ```
 
+### `reload_puppet_server(host)`
+
+Reloads puppetserver to pick up changes made to puppet.conf and other 
+configuration files. *NOTE* This call does not restart the JVM. Rather
+it wraps the `puppetserver reload` subcommand and, as a result, is
+considerable faster than `restart_puppet_server` and should be used in
+place of it whenerver possible.
+
+* Reload puppetserver on the master:
+    ```
+    reload_puppet_server(master)
+    ```
+
 ### `restart_puppet_server(host)`
 
 Restarts the puppetserver service to pickup configuration changes
@@ -116,6 +129,17 @@ process to force reloading configuration files. See
 
     ```
     restart_puppet_server(master)
+    ```
+
+### `rotate_puppet_server_log(host)`
+
+Performs a log file rotation on the puppetserver log file.  
+Intended to mimic what logback would do, which is a copy truncate.
+
+* Rotate the puppetserver log file on the master:
+
+    ```
+    rotate_puppet_server_log(master)
     ```
 
 ### `set_perms_on_remote(host, path, mode)`
@@ -134,15 +158,4 @@ Sets permissions and ownership on a remote file.
     set_perms_on_remote(master, get_site_pp_path(master), '644', :owner => 'root', :group => 'root')
     ```
     
-
-### `rotate_puppet_server_log(host)`
-
-Performs a log file rotation on the puppetserver log file.  
-Intended to mimic what logback would do, which is a copy truncate.
-
-* Rotate the puppetserver log file on the master:
-
-    ```
-    rotate_puppet_server_log(master)
-    ```
 

--- a/lib/master_manipulator/service.rb
+++ b/lib/master_manipulator/service.rb
@@ -3,6 +3,26 @@ require 'json'
 module MasterManipulator
   module Service
 
+    # Reload puppetserver, causing it to reread its config without
+    # restarting the JVM. use this instead of restart_puppet_server 
+    # unless you absolutely have to stop and restart the server because
+    # JVM restarts are very expensive. This implementation relies on
+    # puppetserver's "reload" subcommand, which handles all the waiting
+    # for services to refresh. Older code using a forced HUP on the
+    # server process should be replaced with this.
+    # @param [Beaker::Host] master_host The host to manipulate.
+    # @param [Hash] opts Optional options hash containing options
+    # @return nil
+    # @example Restart the puppetserver process on a PE or FOSS master
+    #   restart_puppet_server(master)
+    def reload_puppet_server(master_host, opts = {})
+      # 2015.x (Everett) and newer
+      rc = on(master_host, "puppetserver reload", :accept_all_exit_codes => true)
+      if rc.exit_code != 0
+        raise "'puppetserver reload' failed, returned: #{rc.exit_code}"
+      end
+    end
+
     # Restart the puppet server and wait for it to come back up or raise
     # an error if the wait times out
     # @param [Beaker::Host] master_host The host to manipulate.


### PR DESCRIPTION
This commit adds support for the trapperkeeper's HUP support in Puppet Server. It provides a wrapper around the `puppetserver reload` subcommand. Reloading the server, previously only available as a shell command, reloads configuration files without having to restart the JVM. As a result, it is much faster to use than restarting the server with `.restart_puppet_server`.

This commit also changes the Rakefile to make rspec use the documentation output format (`--format d`) rather than the default dots.