### PR TITLE
(QA-3116) add method to return puppetserver.log file

### DIFF
--- a/doc/apiref.md
+++ b/doc/apiref.md
@@ -131,6 +131,17 @@ process to force reloading configuration files. See
     restart_puppet_server(master)
     ```
 
+### `puppet_server_log_path(host)`
+
+Returns the location of the puppetserver log file.
+
+* Return the path the puppetserver log file
+
+    ```
+    path = puppet_server_log_path(master)
+
+    ```
+
 ### `rotate_puppet_server_log(host)`
 
 Performs a log file rotation on the puppetserver log file.  

--- a/lib/master_manipulator/log.rb
+++ b/lib/master_manipulator/log.rb
@@ -2,6 +2,16 @@
 module MasterManipulator
   module Log
 
+    # Return the path to the puppetserver log file
+    # @param [Beaker::Host] master_host The puppet server host
+    # @return [String] path to puppetserver log file
+    # @example return the path to the puppet server log file
+    #   puppet_server_log_path(master)
+    def puppet_server_log_path(master_host)
+      log_dir = on(master_host, puppet("master --configprint logdir")).stdout.chomp
+      "#{log_dir}/puppetserver.log"
+    end
+
     #<fileNamePattern>/var/log/puppetlabs/puppetserver/puppetserver-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
 
     # Rollover the puppetserver log file the same way logback would
@@ -11,9 +21,7 @@ module MasterManipulator
     #   rotate_puppet_server_log(master)
     def rotate_puppet_server_log(master_host)
 
-      log_dir = on(master_host, "puppet config print logdir").stdout.chomp
-      #this is ugly, rev 2 should parse the logback.xml, doesn't seem to be another way
-      log_file = log_dir + "server/puppetserver.log"
+      log_file = puppet_server_log_path(master_host)
 
       date_str = on(master_host, "date +%Y-%m-%d").stdout.chomp
       backup_log_file = log_file.sub(/\log$/,date_str)

--- a/spec/master_manipulator/log_spec.rb
+++ b/spec/master_manipulator/log_spec.rb
@@ -3,36 +3,55 @@ require 'fileutils'
 
 describe MasterManipulator::Log do
 
-  let(:beaker_host)           { instance_double(Beaker::Host) }
-  let(:dummy_class)           { Class.new { extend MasterManipulator::Log} }
-#  let(:beaker_command)        { instance_double(Beaker::Command) }
-  let(:log_dir)               { "/tmp/MasterManipulator_Log/#{Process.pid}/puppetlabs/puppet" }
-  let(:log_dir_to_make)       { "/tmp/MasterManipulator_Log/#{Process.pid}/puppetlabs/puppetserver" }
-  let(:log_file)              { "/tmp/MasterManipulator_Log/#{Process.pid}/puppetlabs/puppetserver/puppetserver.log" }
-  let(:backup_log_file_base)  { "/tmp/MasterManipulator_Log/#{Process.pid}/puppetlabs/puppetserver/puppetserver.1976-07-04" }
-  let(:cmd_1)                 { 'puppet config print logdir' }
-  let(:cmd_test_log_file)     { "test -f #{log_file}" }
-  let(:cmd_date)              { "date +%Y-%m-%d" }
+  let(:beaker_host)                      { instance_double(Beaker::Host) }
+  let(:beaker_command)                   { instance_double(Beaker::Command) }
+  let(:dummy_class)                      { Class.new { extend MasterManipulator::Log} }
+  let(:log_dir)                          { "/tmp/MasterManipulator_Log/#{Process.pid}/puppetlabs/puppetserver" }
+  let(:log_file)                         { "/tmp/MasterManipulator_Log/#{Process.pid}/puppetlabs/puppetserver/puppetserver.log" }
+  let(:backup_log_file_base)             { "/tmp/MasterManipulator_Log/#{Process.pid}/puppetlabs/puppetserver/puppetserver.1976-07-04" }
+  let(:cmd_master_configprint_logdir)    { 'master --configprint logdir' }
+  let(:cmd_test_log_file)                { "test -f #{log_file}" }
+  let(:cmd_date)                         { "date +%Y-%m-%d" }
   let(:cmd_test_backup_log_file_generic) { "test -f #{backup_log_file_base}.*" }
-  let(:cmd_test_backup_log_file_0) { "test -f #{backup_log_file_base}.0.log" }
-  let(:cmd_test_backup_log_file_1) { "test -f #{backup_log_file_base}.1.log*" }
-  let(:max_trys)              { 100 }
+  let(:cmd_test_backup_log_file_0)       { "test -f #{backup_log_file_base}.0.log" }
+  let(:cmd_test_backup_log_file_1)       { "test -f #{backup_log_file_base}.1.log*" }
+  let(:max_trys)                         { 100 }
 
 
   def shared_dsl_expectations
     log_result = Beaker::Result.new('host', 'cmd')
     log_result.stdout = log_dir
-    expect(dummy_class).to receive(:on).with(beaker_host, cmd_1).and_return(log_result)
+    expect(dummy_class).to receive(:on).with(beaker_host, beaker_command).and_return(log_result)
+    expect(dummy_class).to receive(:puppet).with(cmd_master_configprint_logdir).and_return(beaker_command)
 
     date_result = Beaker::Result.new('host', 'cmd')
     date_result.stdout = "1976-07-04"
     expect(dummy_class).to receive(:on).with(beaker_host, cmd_date).and_return(date_result)
   end
-  
+
 #add test for if log file is missing
 
-  context 'Normal' do 
-      
+  context 'Normal' do
+
+    describe '.puppet_server_log_path' do
+      it 'With correct required argument' do
+        log_dir_result = Beaker::Result.new('host', 'cmd')
+        log_dir_result.stdout = log_dir
+        expect(dummy_class).to receive(:on).with(beaker_host, beaker_command).and_return(log_dir_result)
+        expect(dummy_class).to receive(:puppet).with(cmd_master_configprint_logdir).and_return(beaker_command)
+        r = dummy_class.puppet_server_log_path(beaker_host)
+        expect(r).to eq(log_file)
+      end
+
+      it 'With too many arguments' do
+        expect{ dummy_class.puppet_server_log_path(beaker_host, {}, 'No Bueno') }.to raise_error(ArgumentError)
+      end
+
+      it 'With no arguments' do
+        expect{ dummy_class.puppet_server_log_path }.to raise_error(ArgumentError)
+      end
+    end
+
     describe '.rotate_puppet_server_log' do
       it 'With correct required argument' do
         shared_dsl_expectations
@@ -62,7 +81,7 @@ describe MasterManipulator::Log do
         backup_log_file_0_test_result = Beaker::Result.new('host', 'cmd')
         backup_log_file_0_test_result.exit_code = 0
         expect(dummy_class).to receive(:on).with(beaker_host, /#{cmd_test_backup_log_file_0}/, :accept_all_exit_codes => true ).and_return(backup_log_file_0_test_result)
-      
+
         backup_log_file_1_test_result = Beaker::Result.new('host', 'cmd')
         backup_log_file_1_test_result.exit_code = 1
         expect(dummy_class).to receive(:on).with(beaker_host, /#{cmd_test_backup_log_file_1}/, :accept_all_exit_codes => true ).and_return(backup_log_file_1_test_result)
@@ -81,7 +100,7 @@ describe MasterManipulator::Log do
       it 'With no arguments' do
         expect{ dummy_class.rotate_puppet_server_log }.to raise_error(ArgumentError)
       end
-      
+
       it 'Log missing' do
         shared_dsl_expectations
         file_test_result = Beaker::Result.new('host', 'cmd')


### PR DESCRIPTION
Add a method that returns where the puppetserver.log file
so we can check it for specific entries